### PR TITLE
Fix typos with word 'match' and its plurals

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -3321,7 +3321,7 @@ margin_left = 465.0
 margin_right = 551.0
 margin_bottom = 26.0
 size_flags_horizontal = 3
-text = "c : t Matchs"
+text = "c : t Matches"
 items = [ "Scence Abx / s1n1act : Action / 3 - ... queried part sample ...", null, 0, false, false, 0, 0, null, "", false, "Scence Abx / s1n3 : Change Var / Note - ... query....", null, 0, false, false, 1, 0, null, "", false ]
 
 [node name="NextMatch" type="Button" parent="Editor/Bottom/QueryPanel/HBoxContainer"]

--- a/runtimes/html-js/modules/condition.js
+++ b/runtimes/html-js/modules/condition.js
@@ -252,7 +252,7 @@ class ConditionStatement {
                             result = ( left.search(regex) >= 0);
                         } catch(err) {
                             if (_VERBOSE){
-                                console.warn(`Evaluation Failed! Bad RegEx Macth operation: ` + err);
+                                console.warn(`Evaluation Failed! Bad RegEx Match operation: ` + err);
                                 console.warn(arguments);
                             }
                         }

--- a/scripts/editor/query.gd
+++ b/scripts/editor/query.gd
@@ -29,7 +29,7 @@ var _STATISTICS = { "current": 0 , "total": 0 }
 
 # CAUTION! This should correspond to the match arms in `central_mind::query_dataset`
 const HOWS = {
-	1: { "text": "Any Macth", "command": "any" },
+	1: { "text": "Any Match", "command": "any" },
 	2: { "text": "Including", "command": "including" },
 	3: { "text": "Exact Match", "command": "exact" },
 	4: { "text": "RegEx", "command": "regexp" },


### PR DESCRIPTION
There was also an instance in `runtimes/html-js.arrow-runtime`, but I'm assuming this is generated dynamically?

I also omitted any instances where it wasn't just text, and was instead the name of a class or node.