### PR TITLE
Deleting nodes with DEL only and not CTRL+DEL

### DIFF
--- a/scripts/editor/grid_graph_edit.gd
+++ b/scripts/editor/grid_graph_edit.gd
@@ -549,9 +549,11 @@ func _gui_input(event: InputEvent) -> void:
 							request_mind("clipboard_push_selection", CLIPBOARD_MODE.CUT)
 					KEY_V:
 						request_mind("clipboard_pull", offset_from_position( self.get_local_mouse_position() ) )
-					KEY_DELETE:
-						request_mind("clean_clipboard", null)
-						if _ALREADY_SELECTED_NODE_IDS.size() != 0:
-							if Main.Mind.batch_remove_resources(_ALREADY_SELECTED_NODE_IDS, "nodes", true, true): # check-only
-								request_mind("remove_selected_nodes", null)
+	# delete selected node
+	if event is InputEventKey && event.is_echo() == false && event.is_pressed() == true :
+		if event.get_scancode() == KEY_DELETE:
+			request_mind("clean_clipboard", null)
+			if _ALREADY_SELECTED_NODE_IDS.size() != 0:
+				if Main.Mind.batch_remove_resources(_ALREADY_SELECTED_NODE_IDS, "nodes", true, true): # check-only
+					request_mind("remove_selected_nodes", null)
 	pass


### PR DESCRIPTION
This little change is meant to change the shortcut to delete nodes, so that hitting DEL will delete the node, with no more needs to hit CTRL+DEL (really annoying and unusual, I needed to look at the source to find out that it was possible to delete a node with a shortcut)