### PR TITLE
Fix Display of Content and Brief in Console

### DIFF
--- a/nodes/content/console.gd
+++ b/nodes/content/console.gd
@@ -32,6 +32,7 @@ var _DEFERRED_VIEW_PLAY_SLOT:int = -1
 onready var Title = get_node("./ContentPlay/Title")
 onready var Content = get_node("./ContentPlay/Content")
 onready var Brief = get_node("./ContentPlay/Brief")
+onready var BriefMargin = get_node("./ContentPlay/AfterBriefMargin")
 onready var Continue = get_node("./ContentPlay/Continue")
 
 const TITLE_UNSET_MESSAGE = "Untitled"
@@ -92,20 +93,21 @@ func setup_view() -> void:
 		var reformatted_content = _NODE_RESOURCE.data.content.format(_CURRENT_VARIABLES_VALUE_BY_NAME)
 		# then because this node type supports BBCode ...
 		Content.clear() # clean up and try to set bbcode
-		if Content.append_bbcode(reformatted_content) != OK:
-			# or normal text if there was problem parsing it
-			Content.set_text(reformatted_content)
+		Content.set_bbcode(reformatted_content)
 	else:
 		Content.set_deferred("text", CONTENT_UNSET_MESSAGE)
 	# Brief
 	if resource_has_valid_string_data("brief"):
+		Brief.set_visible(true)
+		BriefMargin.set_visible(true)
+
 		# ditto ...
 		var reformatted_brief = _NODE_RESOURCE.data.brief.format(_CURRENT_VARIABLES_VALUE_BY_NAME)
 		Brief.clear()
-		if Brief.append_bbcode(reformatted_brief) != OK:
-			Brief.set_text(reformatted_brief)
+		Brief.set_bbcode("[{brief}]".format({ "brief": reformatted_brief }))
 	else:
-		Brief.set_deferred("text", BRIEF_UNSET_MESSAGE)
+		Brief.set_visible(false)
+		BriefMargin.set_visible(false)
 	# ask for console clearance ...
 	if content_wants_clearance():
 		emit_signal("clear_up")

--- a/nodes/content/console.tscn
+++ b/nodes/content/console.tscn
@@ -5,17 +5,14 @@
 [node name="Content" type="PanelContainer"]
 margin_top = 46.0
 margin_right = 221.0
-margin_bottom = 146.0
+margin_bottom = 174.0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ContentPlay" type="VBoxContainer" parent="."]
 margin_left = 7.0
 margin_top = 7.0
 margin_right = 214.0
-margin_bottom = 112.0
+margin_bottom = 140.0
 mouse_filter = 2
 alignment = 1
 
@@ -25,37 +22,51 @@ margin_bottom = 14.0
 text = "{ Title }"
 align = 1
 
-[node name="Brief" type="RichTextLabel" parent="ContentPlay"]
+[node name="AfterTitleMargin" type="MarginContainer" parent="ContentPlay"]
 margin_top = 18.0
 margin_right = 207.0
-margin_bottom = 33.0
+margin_bottom = 28.0
+rect_min_size = Vector2( 0, 10 )
+mouse_filter = 2
+
+[node name="Brief" type="RichTextLabel" parent="ContentPlay"]
+margin_top = 32.0
+margin_right = 207.0
+margin_bottom = 47.0
 mouse_filter = 2
 bbcode_enabled = true
-bbcode_text = "{ Rich text with [color=green] BBCode[/color] brief }"
-text = "{ Rich text with  BBCode brief }"
+bbcode_text = "{ Rich text with [color=green]BBCode[/color] brief }"
+text = "{ Rich text with BBCode brief }"
 fit_content_height = true
 
-[node name="Content" type="RichTextLabel" parent="ContentPlay"]
-margin_top = 37.0
+[node name="AfterBriefMargin" type="MarginContainer" parent="ContentPlay"]
+margin_top = 51.0
 margin_right = 207.0
-margin_bottom = 67.0
+margin_bottom = 61.0
+rect_min_size = Vector2( 0, 10 )
+mouse_filter = 2
+
+[node name="Content" type="RichTextLabel" parent="ContentPlay"]
+margin_top = 65.0
+margin_right = 207.0
+margin_bottom = 95.0
 mouse_filter = 2
 bbcode_enabled = true
 bbcode_text = "{ Rich text with [color=yellow] BBCode[/color] content }"
 text = "{ Rich text with  BBCode content }"
 fit_content_height = true
 
-[node name="Margin" type="MarginContainer" parent="ContentPlay"]
-margin_top = 71.0
+[node name="AfterContentMargin" type="MarginContainer" parent="ContentPlay"]
+margin_top = 99.0
 margin_right = 207.0
-margin_bottom = 81.0
+margin_bottom = 109.0
 rect_min_size = Vector2( 0, 10 )
 mouse_filter = 2
 
 [node name="Continue" type="Button" parent="ContentPlay"]
 margin_left = 138.0
-margin_top = 85.0
+margin_top = 113.0
 margin_right = 207.0
-margin_bottom = 105.0
+margin_bottom = 133.0
 size_flags_horizontal = 8
 text = "Continue"


### PR DESCRIPTION
Fixes #39.

This is a quick fix for #39 that also makes a couple non-fix changes to the display of content:

- There is now a margin between the title, the brief and the content
- The brief will completely disappear if empty instead of saying "No brief"
- If there is a breif it will be printed between square brackets to distinguish it from the content.